### PR TITLE
Add static multi-page portfolio prototype

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About — Yash Verma</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="page page--about">
+    <header class="site-header">
+      <div class="site-header__inner container">
+        <a href="index.html" class="logo">YV.</a>
+        <button class="menu-toggle" id="menuToggle" aria-label="Open menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav class="site-nav" id="siteNav">
+          <a class="site-nav__link" href="index.html">Home</a>
+          <a class="site-nav__link site-nav__link--active" href="about.html">About</a>
+          <a class="site-nav__link" href="projects.html">Projects</a>
+          <a class="site-nav__link" href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <div class="container">
+          <p class="eyebrow">About me</p>
+          <h1>Design leader bridging strategy and craft.</h1>
+          <p class="page-hero__intro">
+            I translate ambitious ideas into experiences that resonate. Over the
+            past 8+ years, I have collaborated with startups and enterprises to
+            shape digital products that deliver measurable impact.
+          </p>
+        </div>
+      </section>
+
+      <section class="bio container">
+        <div class="bio__grid">
+          <div class="bio__column">
+            <h2>Design philosophy</h2>
+            <p>
+              I believe design thrives where curiosity meets rigour. Every
+              engagement begins with understanding people—customers, stakeholders,
+              and the teams who bring products to life.
+            </p>
+            <p>
+              By grounding every decision in research and measurable outcomes, I
+              help create experiences that are emotionally resonant and
+              operationally sound.
+            </p>
+          </div>
+          <div class="bio__column">
+            <h2>Experience snapshot</h2>
+            <ul class="timeline">
+              <li>
+                <span class="timeline__date">2022 — Present</span>
+                <div>
+                  <h3>Lead Product Designer · Flowstate Analytics</h3>
+                  <p>
+                    Leading design systems, data visualisation, and research for
+                    an analytics platform serving 50k+ users globally.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline__date">2019 — 2022</span>
+                <div>
+                  <h3>Senior UX Designer · Aura Bank</h3>
+                  <p>
+                    Spearheaded the redesign of mobile and web experiences,
+                    boosting active usage by 28% in the first quarter.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <span class="timeline__date">2016 — 2019</span>
+                <div>
+                  <h3>Product Designer · Nimbus Care</h3>
+                  <p>
+                    Collaborated with cross-functional teams to modernise patient
+                    onboarding, reducing churn by 18%.
+                  </p>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="values">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">Values</p>
+            <h2>The principles that shape my approach</h2>
+          </div>
+          <div class="values__grid">
+            <article class="value-card">
+              <h3>Clarity</h3>
+              <p>Every project starts by aligning on goals, outcomes, and what success means.</p>
+            </article>
+            <article class="value-card">
+              <h3>Empathy</h3>
+              <p>Deep listening ensures that the solutions we ship truly serve real people.</p>
+            </article>
+            <article class="value-card">
+              <h3>Collaboration</h3>
+              <p>Design is a team sport. I love co-creating with product, engineering, and leadership.</p>
+            </article>
+            <article class="value-card">
+              <h3>Iteration</h3>
+              <p>We move fast, test often, and evolve ideas based on evidence.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="awards">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">Recognition</p>
+            <h2>Awards &amp; Features</h2>
+          </div>
+          <ul class="awards__list">
+            <li>
+              <span>2023</span>
+              <span>Product Hunt Maker Spotlight</span>
+              <span>Flowstate Analytics launch</span>
+            </li>
+            <li>
+              <span>2021</span>
+              <span>UX Design Awards Finalist</span>
+              <span>Aura Bank omni-channel redesign</span>
+            </li>
+            <li>
+              <span>2020</span>
+              <span>Behance Interaction Design</span>
+              <span>Nimbus Care Hybrid Care Platform</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="cta cta--secondary">
+        <div class="container cta__inner">
+          <div class="cta__text">
+            <p class="eyebrow">Next steps</p>
+            <h2>Let’s build something meaningful together.</h2>
+            <p>
+              Curious about how we could collaborate? Explore my latest projects
+              or reach out to kick off a discovery call.
+            </p>
+          </div>
+          <div class="cta__actions">
+            <a class="btn btn--primary" href="projects.html">Explore projects</a>
+            <a class="btn btn--ghost" href="contact.html">Book a call</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container site-footer__inner">
+        <div>
+          <span class="logo">YV.</span>
+          <p>Designing inclusive digital experiences since 2016.</p>
+        </div>
+        <div class="site-footer__links">
+          <a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
+          <a href="https://www.behance.net" target="_blank" rel="noreferrer">Behance</a>
+          <a href="mailto:hello@yashverma.design">Email</a>
+        </div>
+        <p class="site-footer__copy">© 2024 Yash Verma. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+  </body>
+</html>

--- a/assets/Yash-Verma-Resume.pdf
+++ b/assets/Yash-Verma-Resume.pdf
@@ -1,0 +1,1 @@
+Resume placeholder — replace with actual PDF.

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact — Yash Verma</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="page page--contact">
+    <header class="site-header">
+      <div class="site-header__inner container">
+        <a href="index.html" class="logo">YV.</a>
+        <button class="menu-toggle" id="menuToggle" aria-label="Open menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav class="site-nav" id="siteNav">
+          <a class="site-nav__link" href="index.html">Home</a>
+          <a class="site-nav__link" href="about.html">About</a>
+          <a class="site-nav__link" href="projects.html">Projects</a>
+          <a class="site-nav__link site-nav__link--active" href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <div class="container">
+          <p class="eyebrow">Contact</p>
+          <h1>Let’s create something extraordinary.</h1>
+          <p class="page-hero__intro">
+            Share a few details about your project and I’ll get back within two
+            business days to schedule an intro call.
+          </p>
+        </div>
+      </section>
+
+      <section class="contact container">
+        <div class="contact__grid">
+          <div class="contact__details">
+            <h2>How we can collaborate</h2>
+            <p>
+              From product vision workshops to full redesigns, I partner with
+              teams to uncover opportunities and deliver meaningful outcomes.
+            </p>
+            <ul class="contact__channels">
+              <li>
+                <span>General enquiries</span>
+                <a href="mailto:hello@yashverma.design">hello@yashverma.design</a>
+              </li>
+              <li>
+                <span>Speaking &amp; mentoring</span>
+                <a href="mailto:events@yashverma.design">events@yashverma.design</a>
+              </li>
+              <li>
+                <span>Download resume</span>
+                <a href="assets/Yash-Verma-Resume.pdf" download>Resume.pdf</a>
+              </li>
+            </ul>
+          </div>
+          <form class="contact-form" action="#" method="post">
+            <div class="form-group">
+              <label for="name">Name</label>
+              <input type="text" id="name" name="name" placeholder="Your full name" required />
+            </div>
+            <div class="form-group">
+              <label for="email">Email</label>
+              <input type="email" id="email" name="email" placeholder="your@email.com" required />
+            </div>
+            <div class="form-group">
+              <label for="company">Company</label>
+              <input type="text" id="company" name="company" placeholder="Company or organisation" />
+            </div>
+            <div class="form-group">
+              <label for="budget">Estimated budget</label>
+              <select id="budget" name="budget">
+                <option value="" disabled selected>Select a range</option>
+                <option value="10-25">$10k – $25k</option>
+                <option value="25-50">$25k – $50k</option>
+                <option value="50-100">$50k – $100k</option>
+                <option value="100+">$100k+</option>
+              </select>
+            </div>
+            <div class="form-group form-group--full">
+              <label for="message">Project details</label>
+              <textarea id="message" name="message" rows="4" placeholder="Tell me about your goals"></textarea>
+            </div>
+            <button class="btn btn--primary" type="submit">Submit enquiry</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="faq">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">FAQ</p>
+            <h2>Frequently asked questions</h2>
+          </div>
+          <div class="faq__grid">
+            <article class="faq-item">
+              <h3>What is your typical project timeline?</h3>
+              <p>
+                Most engagements range between 8–12 weeks depending on the scope
+                and team size. We’ll align on milestones together.
+              </p>
+            </article>
+            <article class="faq-item">
+              <h3>Do you collaborate with development teams?</h3>
+              <p>
+                Absolutely. I partner closely with engineering and product to
+                ensure seamless delivery and clear documentation.
+              </p>
+            </article>
+            <article class="faq-item">
+              <h3>Are one-off consultations available?</h3>
+              <p>
+                Yes, I offer strategy sprints and design audits for teams looking
+                for rapid insights.
+              </p>
+            </article>
+            <article class="faq-item">
+              <h3>What if I just need design direction?</h3>
+              <p>
+                We can run workshops or design leadership sessions tailored to your
+                team’s needs.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta">
+        <div class="container cta__inner">
+          <div class="cta__text">
+            <p class="eyebrow">Stay connected</p>
+            <h2>Subscribe for design insights and updates.</h2>
+            <p>Receive occasional notes about product strategy, design ops, and events.</p>
+          </div>
+          <form class="newsletter" action="#" method="post">
+            <label for="newsletter-email" class="sr-only">Email</label>
+            <input
+              type="email"
+              id="newsletter-email"
+              name="newsletter-email"
+              placeholder="Enter your email"
+              required
+            />
+            <button class="btn btn--primary" type="submit">Subscribe</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container site-footer__inner">
+        <div>
+          <span class="logo">YV.</span>
+          <p>Designing inclusive digital experiences since 2016.</p>
+        </div>
+        <div class="site-footer__links">
+          <a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
+          <a href="https://www.behance.net" target="_blank" rel="noreferrer">Behance</a>
+          <a href="mailto:hello@yashverma.design">Email</a>
+        </div>
+        <p class="site-footer__copy">© 2024 Yash Verma. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Yash Verma — Portfolio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="page page--landing">
+    <header class="site-header">
+      <div class="site-header__inner container">
+        <a href="index.html" class="logo">YV.</a>
+        <button class="menu-toggle" id="menuToggle" aria-label="Open menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav class="site-nav" id="siteNav">
+          <a class="site-nav__link" href="index.html">Home</a>
+          <a class="site-nav__link" href="about.html">About</a>
+          <a class="site-nav__link" href="projects.html">Projects</a>
+          <a class="site-nav__link" href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero__content container">
+          <div class="hero__text">
+            <p class="eyebrow">Portfolio 2024</p>
+            <h1 class="hero__title">Designing human-centred digital experiences.</h1>
+            <p class="hero__subtitle">
+              I'm Yash Verma, a product designer focused on crafting purposeful
+              experiences for ambitious teams. I help transform complex problems
+              into elegant interfaces that people love.
+            </p>
+            <div class="hero__cta">
+              <a class="btn btn--primary" href="projects.html">View Projects</a>
+              <a class="btn btn--ghost" href="contact.html">Let’s Talk</a>
+            </div>
+          </div>
+          <div class="hero__feature-card">
+            <div class="feature-card">
+              <div class="feature-card__header">
+                <span class="badge">Featured</span>
+                <span class="feature-card__date">2023 · Product Design</span>
+              </div>
+              <h2 class="feature-card__title">Aura Bank Mobile App</h2>
+              <p class="feature-card__description">
+                Increasing daily engagement by reimagining financial journeys
+                across mobile touchpoints.
+              </p>
+              <a class="feature-card__link" href="projects.html">View Case Study</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="highlight">
+        <div class="container highlight__inner">
+          <div class="highlight__stat">
+            <p class="highlight__number">08+</p>
+            <p class="highlight__label">Years of experience</p>
+          </div>
+          <div class="highlight__divider" aria-hidden="true"></div>
+          <div class="highlight__stat">
+            <p class="highlight__number">24</p>
+            <p class="highlight__label">End-to-end case studies</p>
+          </div>
+          <div class="highlight__divider" aria-hidden="true"></div>
+          <div class="highlight__stat">
+            <p class="highlight__number">16</p>
+            <p class="highlight__label">Global clients served</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="services container" id="services">
+        <div class="section-heading">
+          <p class="eyebrow">Capabilities</p>
+          <h2 class="section-title">Designing for clarity and momentum</h2>
+          <p class="section-intro">
+            From early discovery to final delivery, I partner with product teams
+            to deliver powerful customer experiences.
+          </p>
+        </div>
+        <div class="services__grid">
+          <article class="service-card">
+            <h3>Product Strategy</h3>
+            <p>
+              Prioritising customer needs, aligning teams, and defining the right
+              problems to solve before any pixel is designed.
+            </p>
+          </article>
+          <article class="service-card">
+            <h3>UX &amp; Interaction Design</h3>
+            <p>
+              Designing thoughtful end-to-end flows that balance usability with
+              delightful moments across every platform.
+            </p>
+          </article>
+          <article class="service-card">
+            <h3>Visual &amp; Brand Systems</h3>
+            <p>
+              Creating scalable design languages that keep products consistent and
+              instantly recognisable.
+            </p>
+          </article>
+          <article class="service-card">
+            <h3>Design Ops &amp; Facilitation</h3>
+            <p>
+              Empowering teams through workshops, rituals, and documentation that
+              keep design quality high and predictable.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="projects-preview">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">Selected work</p>
+            <h2 class="section-title">Every project is a story of partnership</h2>
+            <div class="section-actions">
+              <a class="btn btn--text" href="projects.html">See all projects</a>
+            </div>
+          </div>
+          <div class="project-grid">
+            <article class="project-card">
+              <span class="project-card__tag">Fintech</span>
+              <h3 class="project-card__title">Aura Bank</h3>
+              <p class="project-card__summary">
+                Building trust with a comprehensive mobile-first banking
+                experience for a new generation of savers.
+              </p>
+              <a class="project-card__link" href="projects.html#project-aura">View case study</a>
+            </article>
+            <article class="project-card">
+              <span class="project-card__tag">SaaS</span>
+              <h3 class="project-card__title">Flowstate Analytics</h3>
+              <p class="project-card__summary">
+                Helping data teams ship faster with visual dashboards and guided
+                insight flows.
+              </p>
+              <a class="project-card__link" href="projects.html#project-flowstate">View case study</a>
+            </article>
+            <article class="project-card">
+              <span class="project-card__tag">Healthcare</span>
+              <h3 class="project-card__title">Nimbus Care</h3>
+              <p class="project-card__summary">
+                Unifying patient journeys for hybrid care providers in a single
+                modern platform.
+              </p>
+              <a class="project-card__link" href="projects.html#project-nimbus">View case study</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonials">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">Testimonials</p>
+            <h2 class="section-title">Trusted by collaborators worldwide</h2>
+          </div>
+          <div class="testimonial-grid">
+            <figure class="testimonial-card">
+              <blockquote>
+                “Yash is the rare designer who sees both the product strategy and
+                the detailed pixels. Our customer satisfaction scores increased
+                35% after launch.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial-card__name">Hannah Lee</span>
+                <span class="testimonial-card__role">Head of Product, Aura Bank</span>
+              </figcaption>
+            </figure>
+            <figure class="testimonial-card">
+              <blockquote>
+                “He brings clarity to ambiguous projects and elevates the entire
+                team. We shipped a completely reimagined platform in 12 weeks.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial-card__name">Marcus Trent</span>
+                <span class="testimonial-card__role">CTO, Flowstate Analytics</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta">
+        <div class="container cta__inner">
+          <div class="cta__text">
+            <p class="eyebrow">Let’s collaborate</p>
+            <h2>Ready to build the next big thing?</h2>
+            <p>
+              I’m currently partnering with teams on digital products and brand
+              experiences. Share the details of your project and we’ll craft a
+              roadmap together.
+            </p>
+          </div>
+          <div class="cta__actions">
+            <a class="btn btn--primary" href="contact.html">Start a project</a>
+            <a class="btn btn--ghost" href="mailto:hello@yashverma.design">Email me</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container site-footer__inner">
+        <div>
+          <span class="logo">YV.</span>
+          <p>Designing inclusive digital experiences since 2016.</p>
+        </div>
+        <div class="site-footer__links">
+          <a href="https://www.linkedin.com" target="_blank" rel="noreferrer"
+            >LinkedIn</a
+          >
+          <a href="https://www.behance.net" target="_blank" rel="noreferrer"
+            >Behance</a
+          >
+          <a href="mailto:hello@yashverma.design">Email</a>
+        </div>
+        <p class="site-footer__copy">© 2024 Yash Verma. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+  </body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Projects — Yash Verma</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="page page--projects">
+    <header class="site-header">
+      <div class="site-header__inner container">
+        <a href="index.html" class="logo">YV.</a>
+        <button class="menu-toggle" id="menuToggle" aria-label="Open menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <nav class="site-nav" id="siteNav">
+          <a class="site-nav__link" href="index.html">Home</a>
+          <a class="site-nav__link" href="about.html">About</a>
+          <a class="site-nav__link site-nav__link--active" href="projects.html">Projects</a>
+          <a class="site-nav__link" href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <div class="container">
+          <p class="eyebrow">Selected work</p>
+          <h1>A portfolio of outcomes, not deliverables.</h1>
+          <p class="page-hero__intro">
+            Each case study captures how strategic design thinking partnered with
+            execution can help teams launch with confidence.
+          </p>
+        </div>
+      </section>
+
+      <section class="case-studies container">
+        <article class="case-study" id="project-aura">
+          <div class="case-study__content">
+            <span class="case-study__tag">Fintech · Mobile &amp; Web</span>
+            <h2>Aura Bank Omnichannel Experience</h2>
+            <p>
+              Leading the redesign of Aura Bank's digital ecosystem, focusing on
+              trust, transparency, and daily engagement across mobile and web
+              platforms.
+            </p>
+            <ul class="case-study__highlights">
+              <li>28% increase in active users within the first quarter</li>
+              <li>Unified design system across 5 product squads</li>
+              <li>Introduced personalised insights with an 80% satisfaction score</li>
+            </ul>
+            <div class="case-study__actions">
+              <a class="btn btn--primary" href="contact.html">Work with me</a>
+              <a class="btn btn--ghost" href="#project-flowstate">Next project</a>
+            </div>
+          </div>
+          <div class="case-study__visual" aria-hidden="true"></div>
+        </article>
+
+        <article class="case-study" id="project-flowstate">
+          <div class="case-study__content">
+            <span class="case-study__tag">SaaS · Data Visualisation</span>
+            <h2>Flowstate Analytics Platform</h2>
+            <p>
+              Building a scalable analytics platform tailored for data-driven
+              teams, delivering clarity through dashboards and guided insight
+              flows.
+            </p>
+            <ul class="case-study__highlights">
+              <li>Improved onboarding with a 43% increase in trial conversions</li>
+              <li>Shipped in 12 weeks with a flexible component library</li>
+              <li>Raised Series B funding following the product launch</li>
+            </ul>
+            <div class="case-study__actions">
+              <a class="btn btn--primary" href="contact.html">Start your project</a>
+              <a class="btn btn--ghost" href="#project-nimbus">Next project</a>
+            </div>
+          </div>
+          <div class="case-study__visual case-study__visual--alt" aria-hidden="true"></div>
+        </article>
+
+        <article class="case-study" id="project-nimbus">
+          <div class="case-study__content">
+            <span class="case-study__tag">Healthcare · Platform</span>
+            <h2>Nimbus Care Hybrid Care Platform</h2>
+            <p>
+              Designing a unified experience for hybrid care providers that blends
+              in-person appointments with virtual care and continuous monitoring.
+            </p>
+            <ul class="case-study__highlights">
+              <li>Reduced onboarding time by 30% with guided workflows</li>
+              <li>Launched responsive dashboards for clinicians and patients</li>
+              <li>Achieved 4.7/5 user satisfaction within 2 months</li>
+            </ul>
+            <div class="case-study__actions">
+              <a class="btn btn--primary" href="contact.html">Collaborate</a>
+              <a class="btn btn--ghost" href="#top">Back to top</a>
+            </div>
+          </div>
+          <div class="case-study__visual" aria-hidden="true"></div>
+        </article>
+      </section>
+
+      <section class="process">
+        <div class="container">
+          <div class="section-heading">
+            <p class="eyebrow">Process</p>
+            <h2>Guiding teams from discovery to launch</h2>
+          </div>
+          <ol class="process-steps">
+            <li>
+              <h3>Discover</h3>
+              <p>
+                Rapid research sprints, stakeholder interviews, and data reviews to
+                uncover opportunities.
+              </p>
+            </li>
+            <li>
+              <h3>Define</h3>
+              <p>
+                Prioritising problems, mapping journeys, and aligning teams on the
+                roadmap forward.
+              </p>
+            </li>
+            <li>
+              <h3>Design</h3>
+              <p>
+                Iterative prototyping and testing to craft intuitive experiences
+                that solve the right problems.
+              </p>
+            </li>
+            <li>
+              <h3>Deliver</h3>
+              <p>
+                Partnering with engineering to ensure quality handoff, launch, and
+                measurement.
+              </p>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="cta cta--secondary">
+        <div class="container cta__inner">
+          <div class="cta__text">
+            <p class="eyebrow">Ready to partner?</p>
+            <h2>Let’s design the future of your product.</h2>
+            <p>
+              Share your goals and we’ll craft a project plan that meets your team
+              where you are.
+            </p>
+          </div>
+          <div class="cta__actions">
+            <a class="btn btn--primary" href="contact.html">Schedule a call</a>
+            <a class="btn btn--ghost" href="mailto:hello@yashverma.design">Email me</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container site-footer__inner">
+        <div>
+          <span class="logo">YV.</span>
+          <p>Designing inclusive digital experiences since 2016.</p>
+        </div>
+        <div class="site-footer__links">
+          <a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
+          <a href="https://www.behance.net" target="_blank" rel="noreferrer">Behance</a>
+          <a href="mailto:hello@yashverma.design">Email</a>
+        </div>
+        <p class="site-footer__copy">© 2024 Yash Verma. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+  </body>
+</html>

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,19 @@
-readme
+# Portfolio — Static Prototype
+
+This repository contains a static prototype of Yash Verma's portfolio site based on the shared Figma concept. It includes all primary screens (Home, About, Projects, Contact) and interconnected navigation/CTA buttons so the experience can be reviewed end-to-end before polishing content and visuals.
+
+## Structure
+
+- `index.html` – landing page with hero, services, work preview, testimonials, and CTA.
+- `about.html` – biography, values, awards, and CTA.
+- `projects.html` – detailed case studies, design process, and CTA.
+- `contact.html` – contact form, FAQs, and newsletter signup block.
+- `styles.css` – shared visual styles, layout, and responsive rules.
+- `scripts.js` – mobile navigation toggle behaviour.
+- `assets/Yash-Verma-Resume.pdf` – placeholder document linked from the contact page.
+
+## Getting started
+
+Open `index.html` in your browser to explore the prototype. All buttons and navigation links connect to the respective pages.
+
+When you're ready to integrate the real content, replace the placeholder copy and update the resume PDF with the final version.

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,14 @@
+const menuToggle = document.getElementById('menuToggle');
+const siteNav = document.getElementById('siteNav');
+
+if (menuToggle && siteNav) {
+  menuToggle.addEventListener('click', () => {
+    siteNav.classList.toggle('is-open');
+  });
+
+  siteNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      siteNav.classList.remove('is-open');
+    });
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,885 @@
+:root {
+  --bg: #0b0c10;
+  --bg-alt: #11131b;
+  --bg-panel: rgba(255, 255, 255, 0.04);
+  --bg-panel-strong: rgba(255, 255, 255, 0.08);
+  --primary: #6c5ce7;
+  --primary-dark: #5845e4;
+  --text: #f5f6fa;
+  --text-muted: rgba(245, 246, 250, 0.7);
+  --divider: rgba(245, 246, 250, 0.1);
+  --font-family: 'Poppins', sans-serif;
+  --transition: 200ms ease;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: radial-gradient(circle at 20% -10%, rgba(108, 92, 231, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(255, 71, 87, 0.25), transparent 50%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover,
+a:focus {
+  color: var(--primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(16px);
+  background: rgba(11, 12, 16, 0.75);
+  border-bottom: 1px solid var(--divider);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 0.12em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-nav__link {
+  position: relative;
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.site-nav__link--active,
+.site-nav__link:hover {
+  color: var(--text);
+}
+
+.site-nav__link--active::after,
+.site-nav__link:hover::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  bottom: -0.35rem;
+  height: 2px;
+  background: var(--primary);
+  border-radius: 999px;
+}
+
+.menu-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.menu-toggle span {
+  display: block;
+  width: 1.5rem;
+  height: 2px;
+  background: var(--text);
+}
+
+.hero {
+  padding: 8rem 0 5rem;
+}
+
+.hero__content {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: center;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 3vw + 1rem, 3.8rem);
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero__subtitle {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+  max-width: 32rem;
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2.25rem;
+}
+
+.hero__feature-card {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.feature-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  width: min(100%, 28rem);
+  box-shadow: var(--shadow);
+}
+
+.feature-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.badge {
+  background: rgba(108, 92, 231, 0.15);
+  color: var(--primary);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.feature-card__title {
+  font-size: 1.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.feature-card__description {
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+}
+
+.feature-card__link {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.highlight {
+  padding: 3rem 0;
+  border-top: 1px solid var(--divider);
+  border-bottom: 1px solid var(--divider);
+}
+
+.highlight__inner {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.highlight__stat {
+  text-align: center;
+}
+
+.highlight__number {
+  font-size: 2.4rem;
+  font-weight: 600;
+}
+
+.highlight__label {
+  color: var(--text-muted);
+}
+
+.highlight__divider {
+  width: 1px;
+  height: 4rem;
+  background: var(--divider);
+  justify-self: center;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.section-heading .section-title {
+  font-size: clamp(2rem, 2vw + 1rem, 2.8rem);
+}
+
+.section-heading .section-intro {
+  color: var(--text-muted);
+  max-width: 32rem;
+}
+
+.section-heading .section-actions {
+  margin-top: 1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  transition: transform var(--transition), box-shadow var(--transition),
+    background var(--transition), color var(--transition);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--primary), #ff4757);
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(108, 92, 231, 0.4);
+}
+
+.btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(108, 92, 231, 0.55);
+}
+
+.btn--ghost {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: var(--text);
+  background: transparent;
+}
+
+.btn--ghost:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-2px);
+}
+
+.btn--text {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--primary);
+}
+
+.services {
+  padding: 6rem 0 4rem;
+}
+
+.services__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.service-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  min-height: 16rem;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.service-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.service-card h3 {
+  margin-bottom: 1rem;
+}
+
+.service-card p {
+  color: var(--text-muted);
+}
+
+.projects-preview {
+  padding: 5rem 0 6rem;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  min-height: 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-card__tag {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+}
+
+.project-card__summary {
+  color: var(--text-muted);
+  flex: 1;
+}
+
+.project-card__link {
+  font-weight: 600;
+}
+
+.testimonials {
+  padding: 5rem 0;
+  background: var(--bg-alt);
+}
+
+.testimonial-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.testimonial-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.testimonial-card blockquote {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.testimonial-card__role {
+  color: var(--text-muted);
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.cta {
+  padding: 6rem 0;
+}
+
+.cta__inner {
+  background: linear-gradient(120deg, rgba(108, 92, 231, 0.28), rgba(255, 71, 87, 0.28));
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 1.75rem;
+  padding: 3rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.cta--secondary .cta__inner {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+}
+
+.cta__text {
+  max-width: 32rem;
+}
+
+.cta__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 12rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--divider);
+  padding: 3rem 0;
+  background: rgba(11, 12, 16, 0.95);
+}
+
+.site-footer__inner {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.site-footer__links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.site-footer__copy {
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.page-hero {
+  padding: 6rem 0 3rem;
+}
+
+.page-hero h1 {
+  font-size: clamp(2.4rem, 2vw + 1rem, 3.2rem);
+  margin-bottom: 1rem;
+}
+
+.page-hero__intro {
+  max-width: 38rem;
+  color: var(--text-muted);
+}
+
+.bio {
+  padding: 3rem 0 5rem;
+}
+
+.bio__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+}
+
+.bio__column p {
+  color: var(--text-muted);
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.timeline__date {
+  color: var(--primary);
+  font-weight: 600;
+  display: inline-block;
+  margin-bottom: 0.35rem;
+}
+
+.values {
+  padding: 5rem 0;
+  background: var(--bg-alt);
+}
+
+.values__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.value-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.25rem;
+  padding: 2rem;
+}
+
+.value-card p {
+  color: var(--text-muted);
+}
+
+.awards {
+  padding: 5rem 0;
+}
+
+.awards__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--divider);
+  border-radius: 1.5rem;
+  overflow: hidden;
+}
+
+.awards__list li {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 1.5rem 2rem;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.awards__list li + li {
+  border-top: 1px solid var(--divider);
+}
+
+.case-studies {
+  padding: 3rem 0 6rem;
+  display: grid;
+  gap: 3rem;
+}
+
+.case-study {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2.5rem;
+  padding: 2.5rem;
+  border: 1px solid var(--divider);
+  border-radius: 1.75rem;
+  background: var(--bg-panel);
+}
+
+.case-study__tag {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  text-transform: uppercase;
+}
+
+.case-study__content p {
+  color: var(--text-muted);
+}
+
+.case-study__highlights {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.case-study__highlights li::before {
+  content: '•';
+  color: var(--primary);
+  margin-right: 0.5rem;
+}
+
+.case-study__visual {
+  background: linear-gradient(135deg, rgba(108, 92, 231, 0.35), rgba(255, 71, 87, 0.35));
+  border-radius: 1.5rem;
+  min-height: 20rem;
+  box-shadow: var(--shadow);
+}
+
+.case-study__visual--alt {
+  background: linear-gradient(135deg, rgba(46, 213, 115, 0.35), rgba(52, 152, 219, 0.35));
+}
+
+.process {
+  padding: 5rem 0;
+  background: var(--bg-alt);
+}
+
+.process-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.process-steps li {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+}
+
+.contact {
+  padding: 4rem 0 6rem;
+}
+
+.contact__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+}
+
+.contact__details p,
+.contact__channels span,
+.contact__channels a {
+  color: var(--text-muted);
+}
+
+.contact__channels {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.contact-form {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-group label {
+  font-weight: 500;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  color: var(--text);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.form-group select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(255, 255, 255, 0.6) 50%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.6) 50%, transparent 50%);
+  background-position: calc(100% - 1.1rem) calc(1.2rem), calc(100% - 0.8rem) calc(1.2rem);
+  background-size: 0.35rem 0.35rem;
+  background-repeat: no-repeat;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 8rem;
+}
+
+.form-group--full {
+  grid-column: 1 / -1;
+}
+
+.contact-form .btn {
+  grid-column: 1 / -1;
+}
+
+.faq {
+  padding: 5rem 0;
+  background: var(--bg-alt);
+}
+
+.faq__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.75rem;
+}
+
+.faq-item {
+  background: var(--bg-panel);
+  border: 1px solid var(--divider);
+  border-radius: 1.25rem;
+  padding: 2rem;
+}
+
+.faq-item p {
+  color: var(--text-muted);
+}
+
+.newsletter {
+  display: flex;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.75rem;
+  border-radius: 999px;
+}
+
+.newsletter input {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  flex: 1;
+  padding: 0 1rem;
+}
+
+.newsletter input:focus {
+  outline: none;
+}
+
+.newsletter .btn {
+  white-space: nowrap;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 992px) {
+  .hero__content,
+  .case-study,
+  .contact__grid,
+  .bio__grid,
+  .values__grid,
+  .services__grid,
+  .project-grid,
+  .testimonial-grid,
+  .process-steps,
+  .faq__grid,
+  .case-study,
+  .site-footer__inner {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .highlight__inner {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .values__grid,
+  .services__grid,
+  .project-grid,
+  .process-steps {
+    gap: 1.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header__inner {
+    padding: 1rem 0;
+  }
+
+  .menu-toggle {
+    display: flex;
+  }
+
+  .site-nav {
+    position: absolute;
+    top: 100%;
+    right: 1rem;
+    padding: 1.25rem;
+    background: rgba(11, 12, 16, 0.95);
+    border: 1px solid var(--divider);
+    border-radius: 1.25rem;
+    display: none;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: 12rem;
+    box-shadow: var(--shadow);
+  }
+
+  .site-nav.is-open {
+    display: flex;
+  }
+
+  .hero__content,
+  .case-study,
+  .contact__grid,
+  .bio__grid,
+  .values__grid,
+  .services__grid,
+  .project-grid,
+  .testimonial-grid,
+  .process-steps,
+  .faq__grid,
+  .site-footer__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .highlight__inner {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .highlight__divider {
+    display: none;
+  }
+
+  .cta__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cta__actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .newsletter {
+    flex-direction: column;
+    border-radius: 1.25rem;
+  }
+
+  .newsletter input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 0.9rem;
+    background: rgba(255, 255, 255, 0.05);
+  }
+}
+
+@media (max-width: 540px) {
+  .hero {
+    padding-top: 6rem;
+  }
+
+  .hero__feature-card {
+    justify-content: center;
+  }
+
+  .feature-card {
+    padding: 2rem;
+  }
+
+  .highlight__inner {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 2rem;
+  }
+
+  .services__grid,
+  .project-grid,
+  .values__grid,
+  .process-steps,
+  .faq__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .site-footer__inner {
+    text-align: center;
+  }
+
+  .site-footer__links,
+  .site-footer__copy {
+    justify-content: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add multi-section landing page along with about, projects, and contact screens based on the provided concept
- implement shared styling and responsive layout plus mobile navigation toggle behaviour
- document the prototype structure and include a placeholder resume asset

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e5974508788331902e26debfd39f87